### PR TITLE
MetaSwap: Add features that can be swapped according to coin price

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
     "test": "test"
   },
   "scripts": {
-    "build": "npx hardhat compile",
-    "test": "npx hardhat test"
+    "test": "node_modules/.bin/hardhat test",
+    "clean": "node_modules/.bin/hardhat clean",
+    "build": "node_modules/.bin/hardhat compile",
+    "test:Bridge": "NODE_ENV=test node_modules/.bin/hardhat test test/bridge/Bridge.test.ts",
+    "test:BridgeLiquidity": "NODE_ENV=test node_modules/.bin/hardhat test test/bridge/Liquidty.test.ts",
+    "test:GameSwap": "NODE_ENV=test node_modules/.bin/hardhat test test/swap/GameSwap.test.ts",
+    "test:GameToken": "NODE_ENV=test node_modules/.bin/hardhat test test/swap/GameToken.test.ts",
+    "test:MetaSwap": "NODE_ENV=test node_modules/.bin/hardhat test test/swap/MetaSwap.test.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
openWithdrawPoint2Token
closeWithdrawPoint2Token
위 두개의 함수를 호출할 때 보아코인의 가격을 파라메타로 전달할 수 있게 하였습니다.
입력된 포인트는 그 단위가 KRW입니다. 
보아의 가격과 포인트의 량에 맞는 보아량을 내부에서 계산하여 지급합니다.