### PR TITLE
Change the swap target from tokens to coins In MetaSwap

### DIFF
--- a/test/swap/MetaSwap.test.ts
+++ b/test/swap/MetaSwap.test.ts
@@ -1,12 +1,12 @@
 import assert from "assert";
 import { expect } from "chai";
+import { BigNumber } from "ethers";
 import { ethers, waffle } from "hardhat";
 // @ts-ignore
-import { MetaSwap, TestERC20 } from "../../typechain";
-import { BOAToken, ContractUtils } from "../ContractUtils";
+import { MetaSwap } from "../../typechain";
+import { BOACoin, ContractUtils } from "../ContractUtils";
 
 describe("Test of MetaSwap Contract", () => {
-    let bizToken: TestERC20;
     let metaSwap: MetaSwap;
     let depositLockBoxID: string;
     let withdrawLockBoxID: string;
@@ -19,18 +19,17 @@ describe("Test of MetaSwap Contract", () => {
     const user01Signer = provider.getSigner(user01.address);
     const user02Signer = provider.getSigner(user02.address);
 
-    const liquidityAmount = BOAToken(1000000);
-    const token_price = 100;
-    const swap_point = 200;
-    const swap_boa = BOAToken(swap_point / token_price);
-    const boa_unit = BOAToken(1);
+    const liquidity_amount = BOACoin(1000);
+    const swap_amount = BOACoin(100);
+
+    const boa_price = 100;
+    const swap_point = 2000;
+
+    let old_user_balance_bizNet: BigNumber;
 
     before(async () => {
-        const erc20 = await ethers.getContractFactory("TestERC20");
-        bizToken = await erc20.deploy("BOSAGORA Biz BOA Token", "BBOA");
-        await bizToken.deployed();
         const swap = await ethers.getContractFactory("MetaSwap");
-        metaSwap = await swap.deploy(bizToken.address);
+        metaSwap = await swap.deploy();
         await metaSwap.deployed();
     });
 
@@ -38,13 +37,6 @@ describe("Test of MetaSwap Contract", () => {
         depositLockBoxID = ContractUtils.BufferToString(ContractUtils.createLockBoxID());
         withdrawLockBoxID = ContractUtils.BufferToString(ContractUtils.createLockBoxID());
         withdrawLockBoxID2 = ContractUtils.BufferToString(ContractUtils.createLockBoxID());
-    });
-
-    it("Check the game token status", async () => {
-        expect(await bizToken.name()).to.equal("BOSAGORA Biz BOA Token");
-        expect(await bizToken.symbol()).to.equal("BBOA");
-        expect(await bizToken.decimals()).to.equal(7);
-        expect(await bizToken.balanceOf(owner.address)).to.equal(1000000000000000);
     });
 
     it("Register metaSwap contract a manager.", async () => {
@@ -55,111 +47,121 @@ describe("Test of MetaSwap Contract", () => {
     });
 
     it("Send liquidity", async () => {
-        await bizToken.connect(ownerSigner).approve(metaSwap.address, liquidityAmount);
-        await expect(metaSwap.connect(ownerSigner).increaseLiquidity(owner.address, liquidityAmount)).to.emit(
-            metaSwap,
-            "IncreasedLiquidity"
-        );
-        expect(await bizToken.balanceOf(metaSwap.address)).to.equal(liquidityAmount);
-        expect(await metaSwap.balanceOfLiquidity(owner.address)).to.equal(liquidityAmount);
+        await expect(
+            metaSwap.connect(ownerSigner).increaseLiquidity({ from: owner.address, value: liquidity_amount })
+        ).to.emit(metaSwap, "IncreasedLiquidity");
+        expect(await provider.getBalance(metaSwap.address)).to.equal(liquidity_amount);
+        expect(await metaSwap.balanceOfLiquidity(owner.address)).to.equal(liquidity_amount);
     });
 
-    it("Open the lock withdraw box to swap points for tokens.", async () => {
-        expect(await bizToken.connect(user01Signer).balanceOf(user01.address)).to.equal(0);
-        const swap = await metaSwap.connect(managerSigner);
-        await expect(swap.openWithdrawPoint2Token(withdrawLockBoxID, user01.address, swap_point, token_price)).to.emit(
-            swap,
-            "OpenWithdraw"
-        );
-        expect(await bizToken.connect(user01Signer).balanceOf(user01.address)).to.equal(0);
+    context("MetaPoint to Coin", async () => {
+        it("Save current BOACoin balance", async () => {
+            old_user_balance_bizNet = await provider.getBalance(user01.address);
+        });
+
+        it("Open the lock withdraw box to swap points for BOACoin.", async () => {
+            await expect(
+                metaSwap
+                    .connect(managerSigner)
+                    .openWithdrawPoint2BOA(withdrawLockBoxID, user01.address, swap_point, boa_price)
+            ).to.emit(metaSwap, "OpenWithdraw");
+        });
+
+        it("Check the open withdraw lock box.", async () => {
+            const result = await metaSwap.checkWithdrawPoint2BOA(withdrawLockBoxID);
+            assert.strictEqual(result[0].toString(), "1");
+            assert.strictEqual(result[1].toString(), user01.address);
+            assert.strictEqual(result[2].toString(), swap_point.toString());
+        });
+
+        it("Check the open withdraw box with duplicate lockBoxID", async () => {
+            await expect(
+                metaSwap
+                    .connect(managerSigner)
+                    .openWithdrawPoint2BOA(withdrawLockBoxID, user01.address, swap_point, boa_price)
+            ).to.be.reverted;
+        });
+
+        it("Close the withdraw lock box", async () => {
+            await expect(metaSwap.connect(user02Signer).closeWithdrawPoint2BOA(withdrawLockBoxID, boa_price)).to.be
+                .reverted;
+            await expect(metaSwap.connect(managerSigner).closeWithdrawPoint2BOA(withdrawLockBoxID, boa_price)).to.emit(
+                metaSwap,
+                "CloseWithdraw"
+            );
+        });
+
+        it("Test to see if coins have been converted to points", async () => {
+            const ExpectedAmount = BOACoin(swap_point / boa_price).add(old_user_balance_bizNet);
+            expect(await provider.getBalance(user01.address)).to.equal(ExpectedAmount);
+        });
+
+        it("Check the close withdraw lock box", async () => {
+            const result = await metaSwap.checkWithdrawPoint2BOA(withdrawLockBoxID);
+            assert.strictEqual(result[0].toString(), "2");
+            assert.strictEqual(result[1].toString(), user01.address);
+            assert.strictEqual(result[2].toNumber(), swap_point);
+        });
     });
 
-    it("Check the open withdraw lock box.", async () => {
-        const result = await metaSwap.checkWithdrawPoint2Token(withdrawLockBoxID);
-        assert.strictEqual(result[0].toString(), "1");
-        assert.strictEqual(result[1].toString(), user01.address);
-        assert.strictEqual(result[2].toNumber(), swap_point);
-    });
+    context("Coin to MetaPoint", async () => {
+        it("Save current BOACoin balance", async () => {
+            old_user_balance_bizNet = await provider.getBalance(user01.address);
+        });
 
-    it("Check the open withdraw box with duplicate lockBoxID", async () => {
+        it("Open deposit lock box to swap BOACoin for points.", async () => {
+            await expect(
+                metaSwap.connect(user01Signer).openDepositBOA2Point(depositLockBoxID, {
+                    from: user01.address,
+                    value: swap_amount,
+                })
+            ).to.emit(metaSwap, "OpenDeposit");
+        });
+
+        it("Check the open deposit lock box.", async () => {
+            const result = await metaSwap.checkDepositBOA2Point(depositLockBoxID);
+            assert.strictEqual(result[0].toString(), "1");
+            assert.strictEqual(result[1].toString(), user01.address);
+            assert.strictEqual(result[2].toString(), swap_amount.toString());
+        });
+
+        it("Check the open deposit box with duplicate lockBoxID", async () => {
+            await expect(
+                metaSwap.connect(managerSigner).openDepositBOA2Point(depositLockBoxID, {
+                    from: user01.address,
+                    value: swap_amount,
+                })
+            ).to.be.reverted;
+        });
+
+        it("Close the deposit lock box", async () => {
+            await expect(metaSwap.connect(user02Signer).closeDepositBOA2Point(depositLockBoxID)).to.be.reverted;
+            await expect(metaSwap.connect(managerSigner).closeDepositBOA2Point(depositLockBoxID)).to.emit(
+                metaSwap,
+                "CloseDeposit"
+            );
+        });
+
+        it("Test to see if coins have been converted to points", async () => {
+            const expectedAmount = old_user_balance_bizNet.sub(swap_amount);
+            const amount = await provider.getBalance(user01.address);
+            assert.ok(expectedAmount.gt(amount));
+        });
+
+        it("Check the close deposit lock box", async () => {
+            const result = await metaSwap.checkDepositBOA2Point(depositLockBoxID);
+            assert.strictEqual(result[0].toString(), "2");
+            assert.strictEqual(result[1].toString(), user01.address);
+            assert.strictEqual(result[2].toString(), swap_amount.toString());
+        });
+    });
+    it("Check the over liquidity withdraw", async () => {
+        const liquidity = await metaSwap.balanceOfLiquidity(owner.address);
+        const swap_point_not_enough: BigNumber = liquidity.mul(boa_price).add(1);
         await expect(
             metaSwap
                 .connect(managerSigner)
-                .openWithdrawPoint2Token(withdrawLockBoxID, user02.address, swap_point, token_price)
+                .openWithdrawPoint2BOA(withdrawLockBoxID2, user02.address, swap_point_not_enough, boa_price)
         ).to.be.reverted;
-    });
-
-    it("Close the withdraw lock box", async () => {
-        await expect(metaSwap.connect(user01Signer).closeDepositToken2Point(withdrawLockBoxID)).to.be.reverted;
-        await expect(metaSwap.connect(user02Signer).closeDepositToken2Point(withdrawLockBoxID)).to.be.reverted;
-        await expect(metaSwap.connect(managerSigner).closeWithdrawPoint2Token(withdrawLockBoxID, token_price)).to.emit(
-            metaSwap,
-            "CloseWithdraw"
-        );
-
-        expect(await bizToken.connect(user01Signer).balanceOf(user01.address)).to.equal(
-            BOAToken(swap_point / token_price)
-        );
-    });
-
-    it("Check the close withdraw lock box", async () => {
-        const result = await metaSwap.checkWithdrawPoint2Token(withdrawLockBoxID);
-        assert.strictEqual(result[0].toString(), "2");
-        assert.strictEqual(result[1].toString(), user01.address);
-        assert.strictEqual(result[2].toNumber(), swap_point);
-        assert.strictEqual(result[4].toString(), BOAToken(swap_point / token_price).toString());
-    });
-
-    it("Open deposit lock box to swap tokens for points.", async () => {
-        const token = await bizToken.connect(user01Signer);
-        expect(await token.balanceOf(user01.address)).to.equal(swap_boa);
-        await token.approve(metaSwap.address, swap_boa);
-        expect(await token.allowance(user01.address, metaSwap.address)).to.eq(swap_boa);
-        await expect(metaSwap.connect(user01Signer).openDepositToken2Point(depositLockBoxID, swap_boa)).to.emit(
-            metaSwap,
-            "OpenDeposit"
-        );
-    });
-
-    it("Check the open deposit lock box.", async () => {
-        const result = await metaSwap.checkDepositToken2Point(depositLockBoxID);
-        assert.strictEqual(result[0].toString(), "1");
-        assert.strictEqual(result[1].toString(), user01.address);
-        assert.strictEqual(result[2].toNumber(), swap_boa.toNumber());
-    });
-
-    it("Check the open deposit box with duplicate lockBoxID", async () => {
-        await expect(metaSwap.connect(managerSigner).openDepositToken2Point(depositLockBoxID, swap_boa)).to.be.reverted;
-    });
-
-    it("Close the deposit lock box", async () => {
-        await expect(metaSwap.connect(user01Signer).closeDepositToken2Point(depositLockBoxID)).to.be.reverted;
-        await expect(metaSwap.connect(user02Signer).closeDepositToken2Point(depositLockBoxID)).to.be.reverted;
-        await expect(metaSwap.connect(managerSigner).closeDepositToken2Point(depositLockBoxID)).to.emit(
-            metaSwap,
-            "CloseDeposit"
-        );
-
-        expect(await bizToken.connect(user01Signer).balanceOf(user01.address)).to.equal(0);
-    });
-
-    it("Check the close deposit lock box", async () => {
-        const result = await metaSwap.checkDepositToken2Point(depositLockBoxID);
-        assert.strictEqual(result[0].toString(), "2");
-        assert.strictEqual(result[1].toString(), user01.address);
-        assert.strictEqual(result[2].toNumber(), swap_boa.toNumber());
-    });
-
-    it("Check the over liquidity withdraw", async () => {
-        const swap_point_not_enough = liquidityAmount.mul(token_price).div(boa_unit).add(1);
-        const swap = await metaSwap.connect(managerSigner);
-        await expect(
-            swap.openWithdrawPoint2Token(withdrawLockBoxID2, user02.address, swap_point_not_enough, token_price)
-        ).to.be.reverted;
-
-        const swap_point_enough = liquidityAmount.mul(token_price).div(boa_unit);
-        await expect(
-            swap.openWithdrawPoint2Token(withdrawLockBoxID2, user02.address, swap_point_enough, token_price)
-        ).to.emit(metaSwap, "OpenWithdraw");
     });
 });


### PR DESCRIPTION
MetaSwap 에서 교환 대상을 토큰에서 코인으로 변경합니다.