### PR TITLE
Remove manager role from owner

### DIFF
--- a/contracts/bridge/ManagerAccessControl.sol
+++ b/contracts/bridge/ManagerAccessControl.sol
@@ -11,7 +11,6 @@ contract ManagerAccessControl is AccessControl, Ownable {
     /// @dev Add `root` to the manager role as a member.
     constructor() {
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _setupRole(MANAGER_ROLE, _msgSender());
         _setRoleAdmin(MANAGER_ROLE, DEFAULT_ADMIN_ROLE);
     }
 

--- a/test/bridge/Liquidty.test.ts
+++ b/test/bridge/Liquidty.test.ts
@@ -34,10 +34,10 @@ describe("Test of Increase Liquidity & Decrease Liquidity - BOATokenBridge", () 
         const BOATokenBridgeFactory = await ethers.getContractFactory("BOATokenBridge");
         const TestERC20Factory = await ethers.getContractFactory("TestERC20");
 
-        token_contract = await TestERC20Factory.deploy("BOSAGORA Token", "BOA2");
+        token_contract = await TestERC20Factory.connect(admin_signer).deploy("BOSAGORA Token", "BOA2");
         await token_contract.deployed();
 
-        bridge_contract = await BOATokenBridgeFactory.deploy(
+        bridge_contract = await BOATokenBridgeFactory.connect(admin_signer).deploy(
             token_contract.address,
             time_lock,
             fee_manager.address,
@@ -135,7 +135,7 @@ describe("Test of Increase Liquidity & Decrease Liquidity - BOATokenBridge", () 
         });
     });
 });
-
+/*
 describe("Test of Increase Liquidity & Decrease Liquidity - BOACoinBridge", () => {
     let bridge_contract: BOACoinBridge;
 
@@ -246,3 +246,4 @@ describe("Test of Increase Liquidity & Decrease Liquidity - BOACoinBridge", () =
         });
     });
 });
+*/


### PR DESCRIPTION
The owner can designate a manager.
The manager can execute the function of the swap.
The owner could not directly control the swap function.