### PR TITLE
Ensuring Unique to TokenId of Token Bridge

### DIFF
--- a/contracts/bridge/TokenBridge.sol
+++ b/contracts/bridge/TokenBridge.sol
@@ -53,7 +53,7 @@ contract TokenBridge is ManagerAccessControl {
         ERC20 token = ERC20(_tokenAddress);
 
         // Generate a token ID
-        bytes32 tokenId = sha256(abi.encodePacked(address(this), token.name(), token.symbol()));
+        bytes32 tokenId = sha256(abi.encodePacked(address(this), address(_tokenAddress)));
 
         require(tokenId == _tokenId);
 

--- a/test/ContractUtils.ts
+++ b/test/ContractUtils.ts
@@ -34,12 +34,11 @@ export class ContractUtils {
      * @param name
      * @param symbol
      */
-    public static getTokenId(address: string, name: string, symbol: string): Buffer {
+    public static getTokenId(address: string, tokenAddress: string): Buffer {
         return crypto
             .createHash("sha256")
             .update(ContractUtils.StringToBuffer(address))
-            .update(Buffer.from(name))
-            .update(Buffer.from(symbol))
+            .update(ContractUtils.StringToBuffer(tokenAddress))
             .digest();
     }
 

--- a/test/bridge/TokenBridge.test.ts
+++ b/test/bridge/TokenBridge.test.ts
@@ -42,7 +42,7 @@ describe("Test for Token Bridge", () => {
     });
 
     it("Register a token", async () => {
-        const tokenId1 = ContractUtils.getTokenId(bridge.address, await token1.name(), await token1.symbol());
+        const tokenId1 = ContractUtils.getTokenId(bridge.address, token1.address);
         // Only the manager can call.
         await expect(bridge.connect(other_signer).registerToken(tokenId1, token1.address)).to.be.reverted;
 
@@ -54,7 +54,7 @@ describe("Test for Token Bridge", () => {
         // The same token cannot be registered more than once.
         await expect(bridge.connect(manager_signer).registerToken(tokenId1, token1.address)).to.be.reverted;
 
-        const tokenId2 = ContractUtils.getTokenId(bridge.address, await token2.name(), await token2.symbol());
+        const tokenId2 = ContractUtils.getTokenId(bridge.address, token2.address);
         expect(await bridge.connect(manager_signer).registerToken(tokenId2, token2.address)).to.emit(
             bridge,
             "TokenRegistered"

--- a/test/bridge/TokenBridgeLiquidity.test.ts
+++ b/test/bridge/TokenBridgeLiquidity.test.ts
@@ -47,8 +47,7 @@ describe("Test of Increase Liquidity & Decrease Liquidity - TokenBridge", () => 
         token_id = ContractUtils.BufferToString(
             ContractUtils.getTokenId(
                 bridge_contract.address,
-                await token_contract.name(),
-                await token_contract.symbol()
+                token_contract.address
             )
         );
         expect(await bridge_contract.connect(manager_signer).registerToken(token_id, token_contract.address)).to.emit(

--- a/test/bridge/TokenBridgeSwap.test.ts
+++ b/test/bridge/TokenBridgeSwap.test.ts
@@ -67,14 +67,14 @@ describe("Test Swap of TokenBridge", () => {
 
     before("Register a token", async () => {
         token_id_ethnet = ContractUtils.BufferToString(
-            ContractUtils.getTokenId(bridge_ethnet.address, await token_ethnet.name(), await token_ethnet.symbol())
+            ContractUtils.getTokenId(bridge_ethnet.address, token_ethnet.address)
         );
         expect(
             await bridge_ethnet.connect(manager_signer).registerToken(token_id_ethnet, token_ethnet.address)
         ).to.emit(bridge_ethnet, "TokenRegistered");
 
         token_id_biznet = ContractUtils.BufferToString(
-            ContractUtils.getTokenId(bridge_biznet.address, await token_biznet.name(), await token_biznet.symbol())
+            ContractUtils.getTokenId(bridge_biznet.address, token_biznet.address)
         );
         expect(
             await bridge_biznet.connect(manager_signer).registerToken(token_id_biznet, token_biznet.address)


### PR DESCRIPTION
Token symbols and token names are reusable and guaranteed to be unique.